### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Update system
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
-  software-properties-common build-essential wget curl
+  software-properties-common build-essential wget curl sudo
 
 RUN add-apt-repository ppa:git-core/ppa && apt-get update
 
@@ -22,3 +22,7 @@ RUN update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-20 100
 RUN apt-get autoremove -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+# Enable passwordless sudo
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+  && chmod 0440 /etc/sudoers.d/ubuntu

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM nvidia/cuda:13.0.1-devel-ubuntu24.04
+
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update system
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y \
+  software-properties-common build-essential wget curl
+
+RUN add-apt-repository ppa:git-core/ppa && apt-get update
+
+# Install tooling
+RUN apt-get install -y \
+  cuda-toolkit \
+  ninja-build git cmake=3.28.3-1build7 clangd-20 \
+  libglfw3-dev libglew-dev
+
+RUN update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-20 100
+
+# Clean up
+RUN apt-get autoremove -y && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,12 +30,7 @@
   },
   "postCreateCommand": "bash ./.devcontainer/setup-build.sh",
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {
-	// 	"ghcr.io/devcontainers/features/nvidia-cuda": {
-	// 		"cudaVersion": "13.0",
-	// 		"installToolkit": true
-	// 	}
-	// },
+	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -49,8 +44,8 @@
 				"llvm-vs-code-extensions.vscode-clangd"
 			]
 		}
-	}
+	},
 
-	// "containerUser": "root",
-	// "remoteUser": "root"
+	"containerUser": "ubuntu",
+	"remoteUser": "ubuntu"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "CUDA C++",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"runArgs": [
+    "--gpus=all",
+    "--runtime=nvidia",
+    "--privileged",
+    "--network=host",
+    "--cap-add=SYS_PTRACE",
+    "--security-opt=seccomp=unconfined",
+    "--device=/dev/dri:/dev/dri"
+	],
+	"containerEnv": {
+    "DISPLAY": ":0",
+    "NVIDIA_VISIBLE_DEVICES": "all",
+    "NVIDIA_DRIVER_CAPABILITIES": "all"
+  },
+	"hostRequirements": {
+			"gpu": "optional" 
+	},
+	"remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/usr/local/cuda/bin",
+    "LD_LIBRARY_PATH": "$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64",
+    "XLA_FLAGS": "--xla_gpu_cuda_data_dir=/usr/local/cuda"
+  },
+  "postCreateCommand": "bash ./.devcontainer/setup-build.sh",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {
+	// 	"ghcr.io/devcontainers/features/nvidia-cuda": {
+	// 		"cudaVersion": "13.0",
+	// 		"installToolkit": true
+	// 	}
+	// },
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"nvidia.nsight-vscode-edition",
+				"ms-vscode.cpptools",
+				"llvm-vs-code-extensions.vscode-clangd"
+			]
+		}
+	}
+
+	// "containerUser": "root",
+	// "remoteUser": "root"
+}

--- a/.devcontainer/setup-build.sh
+++ b/.devcontainer/setup-build.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+if [ -d "build" ]; then
+    echo "build folder already exists, done!"
+    exit 0
+fi
+
+mkdir build
+
+echo "setting up Ninja Multi-Config build..."
+cmake -S. -B./build -G "Ninja Multi-Config" \
+    -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
+    -DCMAKE_CUDA_FLAGS_DEBUG="-g -G -O0" \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+echo "setup complete!"

--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,7 @@ bld/
 
 .vscode/*
 !.vscode/launch.json
+!.vscode/tasks.json
 !.vscode/extensions.json
 !.vscode/settings.json
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,8 @@
       "program": "${workspaceFolder}/build/bin/Debug/cis565_path_tracer",
       "cwd": "${workspaceFolder}/build",
       "args": ["../scenes/cornell.json"],
-      "preLaunchTask": "Build Debug"
+      "preLaunchTask": "Build (Debug)",
+      "miDebuggerPath": "/usr/local/cuda/bin/cuda-gdb",
     },
     {
       "name": "CUDA C++: Launch Release",
@@ -29,7 +30,8 @@
       "program": "${workspaceFolder}/build/bin/Release/cis565_path_tracer",
       "cwd": "${workspaceFolder}/build",
       "args": ["../scenes/cornell.json"],
-      "preLaunchTask": "Build Release"
+      "preLaunchTask": "Build (Release)",
+      "miDebuggerPath": "/usr/local/cuda/bin/cuda-gdb",
     },
     {
       "name": "CUDA C++: Attach",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build (Release)",
+      "type": "shell",
+      "command": "cmake",
+      "args": ["--build", ".", "--config=Release"],
+      "options": {
+        "cwd": "${workspaceFolder}/build"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": ["$gcc", "$nvcc"]
+    },
+    {
+      "label": "Build (Debug)",
+      "type": "shell",
+      "command": "cmake",
+      "args": ["--build", ".", "--config=Debug"],
+      "options": {
+        "cwd": "${workspaceFolder}/build"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": ["$gcc", "$nvcc"]
+    }
+  ]
+}


### PR DESCRIPTION
Using [devcontainers](https://containers.dev/), this project should now have a very reproducible build. By running a devcontainer with GPU passthrough, we can containerize all the dependencies and still run debug or run optimized builds with basically native performance.

Requires NVIDIA container runtime setup and enabled in Docker.